### PR TITLE
Fallback key

### DIFF
--- a/cmd.py
+++ b/cmd.py
@@ -36,7 +36,7 @@ class CliWrapper(CliWrapper):
     PATH = [ dirname(realpath(__file__)) ]
     COMMANDS_USAGE_ORDER = ['init',
                             '',
-                            'passphrase', 'escrow',
+                            'passphrase', 'escrow', 'set-fallback',
                             '',
                             'backup', 'list', 'restore', 'restore-rollback',
                             '',

--- a/cmd_backup.py
+++ b/cmd_backup.py
@@ -342,13 +342,21 @@ def main():
         except hb.Error, e:
             # asking for get_credentials() might fail if the hub is down.
             # But If we already have the credentials we can survive that.
-
             if isinstance(e, hub.NotSubscribed) or \
                     not registry.credentials or \
                     registry.credentials.type == 'iamrole':
-                fatal(e)
+                # if we don't have cached credentials we might still be
+                # able to use the fallback credentials
+                if registry.fallback_access_key:
+                    credentials = hub.Credentials.IAMUser(
+                        registry.fallback_access_key,
+                        registry.fallback_secret_key,
+                        None)
+                else:
+                    fatal(e)
+            elif registry.credentials:
+                warn("using cached backup credentials: " + e.description)
 
-            warn("using cached backup credentials: " + e.description)
 
         credentials = registry.credentials
 

--- a/cmd_backup.py
+++ b/cmd_backup.py
@@ -344,6 +344,7 @@ def main():
             # But If we already have the credentials we can survive that.
             if isinstance(e, hub.NotSubscribed) or \
                     not registry.credentials or \
+                    (registry.credentials and hub.credentials_expired(registry.credentials)) or \
                     registry.credentials.type == 'iamrole':
                 # if we don't have cached credentials we might still be
                 # able to use the fallback credentials
@@ -351,14 +352,14 @@ def main():
                     credentials = hub.Credentials.IAMUser(
                         registry.fallback_access_key,
                         registry.fallback_secret_key,
-                        None)
+                        '')
+                    warn("using fallback credentials: " + e.description)
                 else:
                     fatal(e)
-            elif registry.credentials:
+            
+            else:
                 warn("using cached backup credentials: " + e.description)
-
-
-        credentials = registry.credentials
+                credentials = registry.credentials
 
         if registry.hbr:
             try:

--- a/cmd_init.py
+++ b/cmd_init.py
@@ -166,6 +166,7 @@ Generated backup encryption key:
             registry.registry.sub_apikey = None
             registry.registry.credentials = None
     else:
+
         if force or not registry.registry.sub_apikey:
             if not apikey:
                 print "Copy paste the API-KEY from your Hub account's user profile"

--- a/cmd_set_fallback.py
+++ b/cmd_set_fallback.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+# Copyright (c) 2018 TurnKey GNU/Linux - https://www.turnkeylinux.org
+#
+# This file is part of TKLBAM (TurnKey GNU/Linux BAckup and Migration).
+#
+# TKLBAM is open source software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of
+# the License, or (at your option) any later version.
+#
+"""
+Set Fallback
+
+This is used to setup fallback credentials used when access to the Hub is limited
+or not possible.
+
+Arguments:
+
+    FALLBACK-ACCESS-KEY                 Your IAMUser access key
+
+    FALLBACK-SECRET-KEY                 Your IAMUser secret access key
+
+Security warning:
+
+    Providing your AWS IAMUser credentials as a commandline argument is
+    potentially less secure than allowing tklbam-set-fallback to prompt
+    you for it interactively:
+
+    * The shell may save the APIKEY to its history file (e.g., ~/.bash_history)
+    * The FALLBACK-ACCESS-KEY and FALLBACK-SECRET-KEY may briefly show up in the
+      process list.
+
+    AWS IAMUser credentials must exist on your system in plaintext as they are
+    intended to work even when you can only access your AWS bucket and should
+    work automatically without interaction.
+
+"""
+
+import sys
+import registry
+import getopt
+
+def usage(e=None):
+    if e:
+        print >> sys.stderr, "error: " + str(e)
+
+    print >> sys.stderr, "Usage: %s [ -options ]" % sys.argv[0]
+    print >> sys.stderr, __doc__.strip()
+
+    sys.exit(1)
+
+def main():
+    try:
+        opts, args = getopt.gnu_getopt(sys.argv[1:], "h", ["help"])
+    except getopt.GetoptError, e:
+        usage(e)
+
+    fallback_access_key = None
+    fallback_secret_key = None
+
+    for opt, val in opts:
+        if opt in ('-h', '--help'):
+            usage()
+
+    if args:
+        if len(args) > 2:
+            usage()
+        elif len(args) == 1:
+            fallback_access_key = args[0]
+        elif len(args) == 2:
+            fallback_access_key = args[0]
+            fallback_secret_key = args[1]
+    else:
+        usage()
+
+    if not fallback_access_key:
+        print "Copy paste the AWS access key"
+
+        while True:
+            fallback_access_key = raw_input("ACCESS-KEY: ").strip()
+            if fallback_access_key:
+                break
+    if not fallback_secret_key:
+        print "Copy paste the AWS secret access key"
+
+        while True:
+            fallback_secret_key = raw_input("SECRET-KEY: ").strip()
+            if fallback_secret_key:
+                break
+
+    registry.registry.fallback_access_key = fallback_access_key
+    registry.registry.fallback_secret_key = fallback_secret_key
+
+if __name__ == '__main__':
+    main()

--- a/docs/tklbam-faq.txt
+++ b/docs/tklbam-faq.txt
@@ -474,12 +474,19 @@ No, for a couple of reasons:
 2) You can use TKLBAM without linking it to the Hub at all. See the tklbam-init
    --solo option.
 
+3) You can setup fallback access keys to your Amazon S3. Even if the Hub goes
+   down AND your cached credentials become invalidated you're backups can still
+   function as normal.
+
 If the Hub goes down, will my backup cron jobs still work?
 ----------------------------------------------------------
 
 Yes. Backups which have already been configured will continue to work
 normally. If TKLBAM can't reach the Hub it just uses the locally cached
 profile and S3 address.
+
+In the event that locally cached credentials become invalidated you can also
+setup fallback keys to S3 as an additional protective measure.
 
 If my connection to the Hub goes down, can I still restore?
 -----------------------------------------------------------

--- a/docs/tklbam-faq.txt
+++ b/docs/tklbam-faq.txt
@@ -474,8 +474,8 @@ No, for a couple of reasons:
 2) You can use TKLBAM without linking it to the Hub at all. See the tklbam-init
    --solo option.
 
-3) You can setup fallback access keys to your Amazon S3. Even if the Hub goes
-   down AND your cached credentials become invalidated you're backups can still
+3) You can setup fallback credentials to your Amazon S3. Even if the Hub goes
+   down AND your cached credentials become invalidated your backups can still
    function as normal.
 
 If the Hub goes down, will my backup cron jobs still work?

--- a/docs/tklbam-set-fallback.txt
+++ b/docs/tklbam-set-fallback.txt
@@ -1,0 +1,47 @@
+===================
+tklbam-set-fallback
+===================
+
+------------
+Set Fallback
+------------
+
+:Author: Stefan Davis <stefan@turnkeylinux.org>
+:Date:   2018-10-09
+:Manual section: 8
+:Manual group: backup
+
+SYNOPSIS
+========
+
+tklbam-set-fallback [ `FALLBACK-ACCESS-KEY` ] [ `FALLBACK-SECRET-KEY` ]
+
+This is used to setup fallback credentials used when access to the Hub is limited
+or not possible.
+
+ARGUMENTS
+=========
+
+`FALLBACK-ACCESS-KEY`	Your IAMUser access key
+`FALLBACK-SECRET-KEY` 	Your IAMUser secret access key
+
+If you do not provide FALLBACK-ACCESS-KEY and/or FALLBACK-SECRET-KEY you will be
+prompted for it/them interactively.
+
+SECURITY WARNING
+================
+
+Providing your AWS IAMUser credentials as a commandline argument is potentially less secure
+than allowing tklbam-set-fallback to prompt you for it interactively.
+
+* The shell may save the credentials in its history file (e.g. ~/.bash_history)
+* The credentials may briefly show up in the process list.
+
+AWS IAMUser credentials must exist on your system in plaintext as they are intended to work
+even when you can only access your AWS bucket and should work automatically without
+interaction.
+
+SEE ALSO
+========
+
+``tklbam`` (8), ``tklbam-faq`` (7)

--- a/docs/tklbam-set-fallback.txt
+++ b/docs/tklbam-set-fallback.txt
@@ -22,8 +22,8 @@ or not possible.
 ARGUMENTS
 =========
 
-`FALLBACK-ACCESS-KEY`	Your IAMUser access key
-`FALLBACK-SECRET-KEY` 	Your IAMUser secret access key
+`FALLBACK-ACCESS-KEY`   Your IAMUser access key
+`FALLBACK-SECRET-KEY`   Your IAMUser secret access key
 
 If you do not provide FALLBACK-ACCESS-KEY and/or FALLBACK-SECRET-KEY you will be
 prompted for it/them interactively.
@@ -37,9 +37,8 @@ than allowing tklbam-set-fallback to prompt you for it interactively.
 * The shell may save the credentials in its history file (e.g. ~/.bash_history)
 * The credentials may briefly show up in the process list.
 
-AWS IAMUser credentials must exist on your system in plaintext as they are intended to work
-even when you can only access your AWS bucket and should work automatically without
-interaction.
+AWS IAMUser credentials exist on your system in plaintext. This is to allow backups to work
+seamlessly without interaction.
 
 SEE ALSO
 ========

--- a/docs/tklbam.txt
+++ b/docs/tklbam.txt
@@ -151,6 +151,7 @@ COMMANDS
 :list:               List backup records
 :restore:            Restore a backup
 :restore-rollback:   Rollback last restore
+:set-fallback:       Sets additional fallback keys for S3
 
 EXAMPLE USAGE SCENARIO
 ======================

--- a/hub.py
+++ b/hub.py
@@ -208,6 +208,10 @@ class Credentials:
 
         return(creds_types[creds_type](**kwargs))
 
+def credentials_expired(credentials):
+    ''' Checks if credentials object has expired, expects credentials to be non None '''
+    return datetime.strptime(credentials['expiration'], '%Y-%m-%dT%H:%M:%SZ') <= datetime.now()
+
 class Backups:
     API_URL = os.getenv('TKLBAM_APIURL', 'https://hub.turnkeylinux.org/api/backup/')
     Error = Error

--- a/registry.py
+++ b/registry.py
@@ -67,7 +67,8 @@ Run "tklbam-init --help" for further details.
     class Paths(_Paths):
         files = ['restore.log', 'backup.log', 'backup.pid',
                  'backup-resume', 'sub_apikey', 'secret', 'key', 'credentials', 'hbr',
-                 'profile', 'profile/stamp', 'profile/profile_id']
+                 'profile', 'profile/stamp', 'profile/profile_id', 'fallback_access_key',
+                 'fallback_secret_key']
 
     def __init__(self, path=None):
         if path is None:
@@ -114,6 +115,14 @@ Run "tklbam-init --help" for further details.
         retval = cls._file_str(path, d)
         if retval:
             return AttrDict([ v.split("=", 1) for v in retval.split("\n") ])
+
+    def fallback_access_key(self, val=UNDEFINED):
+        return self._file_str(self.path.fallback_access_key, val)
+    fallback_access_key = property(fallback_access_key, fallback_access_key)
+
+    def fallback_secret_key(self, val=UNDEFINED):
+        return self._file_str(self.path.fallback_secret_key, val)
+    fallback_secret_key = property(fallback_secret_key, fallback_secret_key)
 
     def sub_apikey(self, val=UNDEFINED):
         return self._file_str(self.path.sub_apikey, val)


### PR DESCRIPTION
- Added set-fallback tklbam subcommand which allows setting a fallback access and secret access key for AWS.
- Added fallback access and secret access key sections to registry.
- Allowed fallback keys to be used automatically when no cached credentials exist or when cached credentials have expired.

NOTE: Does not update hub of offline backups.