### PR TITLE
Update fixclock hook to py3, update & fix example hooks and move to /etc

### DIFF
--- a/contrib/example-hook-post-restore
+++ b/contrib/example-hook-post-restore
@@ -1,16 +1,19 @@
 #!/bin/bash -e
-# This is a disabled hook example. 
-# To enable, make it executable: chmod +x /etc/tklbam/hooks.d/post-restore
+# This is a disabled hook example.
+#
+# To enable, make it executable:
+#
+#     chmod +x /etc/tklbam/hooks.d/example-post-restore
 
 # hooks are always called with two arguments
 op=$1
 state=$2
 
-if [ "$state" = "pre" ] && [ "$op" = "backup" ]; then
+if [[ "$state" == "post" ]] && [[ "$op" == "restore" ]]; then
 
     echo "HOOK $0 :: op=$op state=$state pwd=$(pwd) :: "
 
-    # e.g., restart services...
+    # run some commands here...
+    # e.g. restart services, load data dumps, etc
 
 fi
-

--- a/contrib/example-hook-pre-backup
+++ b/contrib/example-hook-pre-backup
@@ -1,14 +1,18 @@
 #!/bin/bash -e
-# This is a disabled hook example. 
-# To enable, make it executable: chmod +x /etc/tklbam/hooks.d/pre-backup
+# This is a disabled hook example.
+#
+# To enable, make it executable:
+#
+#     chmod +x /etc/tklbam/hooks.d/example-pre-backup
 
 # hooks are always called with two arguments
 op=$1
 state=$2
 
-if [ "$state" = "pre" ] && [ "$op" = "backup" ]; then
+if [[ "$state" == "pre" ]] && [[ "$op" = "backup" ]]; then
 
     echo "HOOK $0 :: op=$op state=$state pwd=$(pwd) :: "
 
+    # run some commands here...
+    # e.g. clear caches, dump some data to the filesystem, etc
 fi
-

--- a/contrib/fixclock-hook
+++ b/contrib/fixclock-hook
@@ -1,9 +1,9 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # hook that runs ntpdate before duplicity to sync clock to UTC
 
 import os
 import sys
-import executil
+import subprocess
 from string import Template
 
 NTPSERVER = os.environ.get("NTPSERVER", "2.pool.ntp.org")
@@ -32,15 +32,14 @@ $ERROR
 def fixclock():
     os.environ['PATH'] += ':/usr/sbin'
 
-    command = "ntpdate -u " + NTPSERVER
+    command = ["ntpdate", "-u", NTPSERVER]
 
-    try:
-        executil.getoutput(command)
-    except executil.ExecError, e:
-        msg = Template(ERROR_TPL).substitute(COMMAND=command,
-                                             ERROR=e.output)
+    p = subprocess.run(command, capture_output=True, text=True)
+    if p.returncode != 0:
+        msg = Template(ERROR_TPL).substitute(COMMAND=' '.join(command),
+                                             ERROR=p.stderr)
 
-        print >> sys.stderr, msg,
+        print(msg, end=' ', file=sys.stderr)
         sys.exit(1)
 
 def main():

--- a/debian/tklbam.install
+++ b/debian/tklbam.install
@@ -2,10 +2,10 @@
 
 contrib/example-conf => /etc/tklbam/conf
 contrib/example-overrides => /etc/tklbam/overrides
-contrib/example-hook => /etc/tklbam/hooks.d/example
 contrib/fixclock-hook => /etc/tklbam/hooks.d/fixclock
 contrib/cron.sh => /etc/cron.daily/tklbam-backup
 
-contrib/example-hook-pre-backup => /usr/share/tklbam/contrib/example-hook-pre-backup
-contrib/example-hook-post-restore => /usr/share/tklbam/contrib/example-hook-post-restore
+contrib/example-hook => /etc/tklbam/hooks.d/example
+contrib/example-hook-pre-backup => /etc/tklbam/hooks.d/example-pre-backup
+contrib/example-hook-post-restore => /etc/tklbam/hooks.d/example-post-restore
 contrib/ez-apt-install.sh => /usr/share/tklbam/contrib/ez-apt-install.sh


### PR DESCRIPTION
- Update fixclock hook to py3 (doesn't require py2)
- update & fix example hooks and move to /etc (from /usr/share)