### PR TITLE
PostgreSQL examples included in example `overrides` & PostgreSQL doc improvements

### DIFF
--- a/contrib/example-overrides
+++ b/contrib/example-overrides
@@ -55,7 +55,7 @@
 #
 # PosgreSQL Format
 #
-#   =?pgsql:database[/table]
+#   -?pgsql:database[/table]
 #
 # PosgreSQL Examples
 #

--- a/contrib/example-overrides
+++ b/contrib/example-overrides
@@ -41,14 +41,26 @@
 #   
 #   You can mix positive overrides with negative overrides.
 # 
-# Format
+# MySQL/MariaDB Format
 #
 #   -?mysql:database[/table]
 # 
-# Examples
+# MySQL/MariaDB Examples
 # 
 #   (exclude Drupal10 sessions table)
 #   -mysql:drupal10/sessions
 # 
 #   (only include drupal10 database)
 #   mysql:drupal10
+#
+# PosgreSQL Format
+#
+#   =?pgsql:database[/table]
+#
+# PosgreSQL Examples
+#
+#   (exclude my_db test table)
+#   -pgsql:my_db:test
+#
+#   (only include my_db database)
+#   pgsql:my_db

--- a/docs/tklbam-backup.txt
+++ b/docs/tklbam-backup.txt
@@ -64,14 +64,34 @@ Database overrides
 
 ``<database-override>`` := -?pgsql:database[/table]
 
-By default ALL databases and database tables are backed up. 
+By default ALL MySQL/MariaDB databases and database tables are backed up.
 
-Adding a positive override (e.g., mysql:mydatabase) changes the default
-behavior so that only the database or table specified in the override is
-included in the backup.
+Similarly, ALL PostgreSQL are included - with the exception of the `postgres`
+database - an empty database included by default in all PostgreSQL installs.
 
-Negative overrides exclude a database (e.g., -mysql:mydatabase) or table (e.g.,
--mysql:mydatabase/mytable) from being included in the backup. 
+Exclusion of default `postgres` PostgreSQL database
+---------------------------------------------------
+
+The exclusion of the `postgres` database can NOT be overriden, even if
+explictly added as an override.
+
+Some documentation suggests that it is "best practice" to not use the default
+`postgres` database for user data. However, there is no documented strict
+reason why it shouldn't be used. So the inability to include this database is
+considered a bug and will be addressed in a future TKLBAM update. If you are
+already using the `postgres` database, the database can be renamed, or you can
+move your data to a new database.
+
+Database override details
+-------------------------
+
+Adding a positive override (e.g., mysql:mydatabase / pgsql:mydatabase )
+changes the default behavior so that only the database or table specified in
+the override is included in the backup. If you wish to use overrides to
+include multiple databases but not all, they must all be noted separately.
+
+Negative database/table overrides (with a dash prefix) exclude a database or
+table (e.g. -mysql:mydatabase / -pgsql:mydatabase).
 
 Excluding a table only excludes its data. The schema of an excluded table is
 still backed up, as it takes up a trivial amount of space and other tables or
@@ -81,11 +101,11 @@ You can mix positive overrides with negative overrides.
 
 Examples::
 
-    # exclude Drupal6 sessions table
-    -mysql:drupal6/sessions
+    # exclude Drupal10 sessions table
+    -mysql:drupal10/sessions
 
-    # only include drupal6 database
-    mysql:drupal6
+    # only include drupal10 database
+    mysql:drupal10
 
     # only include mahara postgres database
     pgsql:mahara

--- a/docs/tklbam-restore.txt
+++ b/docs/tklbam-restore.txt
@@ -82,12 +82,13 @@ System restore options
 
 --simulate                        Do a dry run simulation of the system restore
 
---limits=LIMITS                   Restore filesystem or database limitations. You can use this 
-                                  to control what parts of the backup will be restored.
+--limits=LIMITS                   Restore filesystem or database limitations
 
-                                  Preceding a limit with a minus sign
-                                  turns it into an exclusion.
+                                  Used to control what parts of the backup will
+                                  be restored.
 
+                                  Preceding a limit with a minus sign turns it
+                                  into an exclusion.
                                   Mutliple items are space separated. Spaces in paths must be
                                   escaped. E.g. --limits="/path\ with\ spaces -/another\ path"
 


### PR DESCRIPTION
This includes some PostgreSQL (i.e. `pgsql`) examples in the `overrides` file. 

Whilst the general nature of the existing MySQL/MariaDB override examples also apply to PostgreSQL, it's not immediately clear what the limits usage for PostgreSQL is. Whilst I imagine many might assume `pgsql`, PostgreSQL is also often abbreviated to `pgsql`. IMO it's better be explicit.

Closes https://github.com/turnkeylinux/tracker/issues/1948

This PR also includes improvement of the `tklbam-backup` & `tklbam-restore` docs:
- Explicit note that the `mysql` limits also relates to MariaDB
- Explicit examples using `pgsql`
- Included note re bug regarding the exclusion of the (default) `postgres` database. See bug: https://github.com/turnkeylinux/tracker/issues/1943
- Some other rewording/refactoring.

The relevant website doc pages have already been updated to be consistent with the changes in this PR..